### PR TITLE
Add fsgroup as default

### DIFF
--- a/charts/piggy-webhooks/Chart.yaml
+++ b/charts/piggy-webhooks/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: piggy-webhooks
 description: Deploys a piggy-webhooks that inject enviroment variaiables from AWS Secret Manager
 type: application
-version: 0.2.3
-appVersion: "0.2.3"
+version: 0.2.5
+appVersion: "0.2.5"
 home: https://piggysec.com
 icon: https://raw.githubusercontent.com/KongZ/piggy/main/docs/images/piggy.png
 sources:

--- a/charts/piggy-webhooks/values.yaml
+++ b/charts/piggy-webhooks/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: ghcr.io/kongz/piggy-webhooks
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.2.3"
+  tag: "0.2.5"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -30,6 +30,7 @@ podAnnotations: {}
 
 podSecurityContext:
   runAsUser: 10001
+  fsGroup: 65534
 
 securityContext: {}
   # capabilities:
@@ -121,6 +122,6 @@ mutate:
   image:
     repository: ghcr.io/kongz/piggy-env
     pullPolicy: IfNotPresent
-    tag: "0.2.3"
+    tag: "0.2.5"
 
 debug: false


### PR DESCRIPTION
Default EKS privilege requires pod security context fsGroup: 65534 use IRSA
See https://github.com/kubernetes-sigs/external-dns/pull/1185