### PR TITLE
Allow to use golang dns resolver

### DIFF
--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -24,6 +24,10 @@ You can add annotations to kubernetes Pods objects to customize piggy behavior.
 | [piggysec.com/image-pull-secret](#image-pull-secret)                                       | string  |         | Pods     |       |
 | [piggysec.com/image-pull-secret-namespace](#image-pull-secret-namespace)                   | string  |         | Pods     |       |
 | [piggysec.com/image-skip-verify-registry](#image-skip-verify-registry)                     | string  |         | Pods     |       |
+| [piggysec.com/piggy-enforce-service-account](#piggy-enforce-service-account)               | bool    | false   | Pods     |       |
+| [piggysec.com/piggy-default-secret-name-prefix](#piggy-default-secret-name-prefix)         | string  |         | Pods     |       |
+| [piggysec.com/piggy-default-secret-name-suffix](#piggy-default-secret-name-suffix)         | string  |         | Pods     |       |
+| [piggysec.com/piggy-dns-resolver](#piggy-dns-resolver)                                     | string  |         | Pods     |       |
 
 ## AWS Secret Manager
 
@@ -44,7 +48,11 @@ You can add annotations to kubernetes Pods objects to customize piggy behavior.
   - <a name="piggy-enforce-integrity">`piggysec.com/piggy-enforce-integrity`</a> enforce checking command integrity before inject secrets   into. Default to `true`. Set this value to `true` is recommended in most application. Set to `false` will allow piggy-env to run on   different arguments
   - <a name="debug">`piggysec.com/debug`</a> allows to run piggy-env in debug mode. Default to `false`.
   - <a name="standalone">`piggysec.com/standalone`</a> allows to run piggy-env in standalone mode. Default to `false`. If this value is `true`, the [piggysec.com/piggy-address](#piggy-address) will not be used.
-
+  - <a name="piggy-enforce-service-account">`piggysec.com/piggy-enforce-service-account`</a> Force to check `PIGGY_ALLOWED_SA` env value in AWS secret manager
+  - <a name="piggy-default-secret-name-prefix">`piggysec.com/piggy-default-secret-name-prefix`</a>Set default prefix string for secret name
+  - <a name="piggy-default-secret-name-suffix">`piggysec.com/piggy-default-secret-name-suffix`</a>Set default suffix string for secret name
+  - <a name="piggy-dns-resolver">`piggysec.com/piggy-dns-resolver`</a>Set Golang DNS resolver such as `tcp`, `udp`. See https://pkg.go.dev/net
+  
 ## Container image settings
 
   - <a name="image-pull-secret">`piggysec.com/image-pull-secret`</a> a name of container image pull secret. The piggy will try to read the   container image by using secret in the following order

--- a/docs/annotations.md
+++ b/docs/annotations.md
@@ -28,6 +28,7 @@ You can add annotations to kubernetes Pods objects to customize piggy behavior.
 | [piggysec.com/piggy-default-secret-name-prefix](#piggy-default-secret-name-prefix)         | string  |         | Pods     |       |
 | [piggysec.com/piggy-default-secret-name-suffix](#piggy-default-secret-name-suffix)         | string  |         | Pods     |       |
 | [piggysec.com/piggy-dns-resolver](#piggy-dns-resolver)                                     | string  |         | Pods     |       |
+| [piggysec.com/piggy-delay-second](#piggy-delay-second)                                     | int     | 0       | Pods     |       |
 
 ## AWS Secret Manager
 
@@ -51,7 +52,8 @@ You can add annotations to kubernetes Pods objects to customize piggy behavior.
   - <a name="piggy-enforce-service-account">`piggysec.com/piggy-enforce-service-account`</a> Force to check `PIGGY_ALLOWED_SA` env value in AWS secret manager
   - <a name="piggy-default-secret-name-prefix">`piggysec.com/piggy-default-secret-name-prefix`</a>Set default prefix string for secret name
   - <a name="piggy-default-secret-name-suffix">`piggysec.com/piggy-default-secret-name-suffix`</a>Set default suffix string for secret name
-  - <a name="piggy-dns-resolver">`piggysec.com/piggy-dns-resolver`</a>Set Golang DNS resolver such as `tcp`, `udp`. See https://pkg.go.dev/net
+  - <a name="piggy-dns-resolver">`piggysec.com/piggy-dns-resolver`</a>Set Golang DNS resolver such as `tcp`, `udp`. See [https://pkg.go.dev/net](https://pkg.go.dev/net)
+  - <a name="piggy-delay-second">`piggysec.com/piggy-delay-second`</a>Set delay in second before start retrieving secrets. If you are using Istio Envoy, you may need to set this value to 1. The Envoy will block all outgoing requests from piggy-env until Envoy is fully started. Add this delay value to allow Envoy to operate before running piggy.
   
 ## Container image settings
 

--- a/piggy-env/Dockerfile
+++ b/piggy-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-buster as builder
+FROM golang:1.17.1-buster as builder
 ARG VERSION
 ARG COMMIT_HASH
 ARG BUILD_DATE

--- a/piggy-env/go.mod
+++ b/piggy-env/go.mod
@@ -1,8 +1,10 @@
 module github.com/KongZ/piggy/piggy-env
 
-go 1.16
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.38.67
 	github.com/rs/zerolog v1.23.0
 )
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/piggy-env/main.go
+++ b/piggy-env/main.go
@@ -194,7 +194,7 @@ func requestSecrets(references map[string]string, env *sanitizedEnv, sig []byte)
 				PreferGo: true,
 				Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
 					d := net.Dialer{}
-					return d.DialContext(ctx, "tcp", "")
+					return d.DialContext(ctx, dnsResolver, "")
 				},
 			},
 		}

--- a/piggy-webhooks/Dockerfile
+++ b/piggy-webhooks/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-buster as builder
+FROM golang:1.17.1-buster as builder
 ARG VERSION
 ARG COMMIT_HASH
 ARG BUILD_DATE

--- a/piggy-webhooks/go.mod
+++ b/piggy-webhooks/go.mod
@@ -1,6 +1,6 @@
 module github.com/KongZ/piggy/piggy-webhooks
 
-go 1.16
+go 1.17
 
 require (
 	github.com/aws/aws-sdk-go v1.39.5

--- a/piggy-webhooks/mutate/mutate.go
+++ b/piggy-webhooks/mutate/mutate.go
@@ -67,6 +67,7 @@ func (m *Mutating) mergeConfig(config *service.PiggyConfig, annotations map[stri
 	config.ImagePullSecretNamespace = service.GetStringValue(annotations, service.ConfigImagePullSecretNamespace, "")
 	config.ImageSkipVerifyRegistry = service.GetBoolValue(annotations, service.ConfigImageSkipVerifyRegistry, true)
 	config.Standalone = service.GetBoolValue(annotations, service.ConfigStandalone, false)
+	config.PiggyDNSResolver = service.GetStringValue(annotations, service.ConfigPiggyDNSResolver, "")
 	return config
 }
 

--- a/piggy-webhooks/mutate/mutate.go
+++ b/piggy-webhooks/mutate/mutate.go
@@ -68,6 +68,7 @@ func (m *Mutating) mergeConfig(config *service.PiggyConfig, annotations map[stri
 	config.ImageSkipVerifyRegistry = service.GetBoolValue(annotations, service.ConfigImageSkipVerifyRegistry, true)
 	config.Standalone = service.GetBoolValue(annotations, service.ConfigStandalone, false)
 	config.PiggyDNSResolver = service.GetStringValue(annotations, service.ConfigPiggyDNSResolver, "")
+	config.PiggyDelaySecond = service.GetIntValue(annotations, service.ConfigPiggyDelaySecond, 0)
 	return config
 }
 

--- a/piggy-webhooks/mutate/pod.go
+++ b/piggy-webhooks/mutate/pod.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -144,6 +145,15 @@ func (m *Mutating) mutateContainer(uid string, config *service.PiggyConfig, cont
 			{
 				Name:  "PIGGY_DNS_RESOLVER",
 				Value: config.PiggyDNSResolver,
+			},
+		}...)
+	}
+	if config.PiggyDelaySecond > 0 {
+		val := strconv.FormatInt(int64(config.PiggyDelaySecond), 10)
+		container.Env = append(container.Env, []corev1.EnvVar{
+			{
+				Name:  "PIGGY_DELAY_SECOND",
+				Value: val,
 			},
 		}...)
 	}

--- a/piggy-webhooks/mutate/pod.go
+++ b/piggy-webhooks/mutate/pod.go
@@ -139,6 +139,14 @@ func (m *Mutating) mutateContainer(uid string, config *service.PiggyConfig, cont
 			},
 		}...)
 	}
+	if config.PiggyDNSResolver != "" {
+		container.Env = append(container.Env, []corev1.EnvVar{
+			{
+				Name:  "PIGGY_DNS_RESOLVER",
+				Value: config.PiggyDNSResolver,
+			},
+		}...)
+	}
 	log.Debug().Str("namespace", pod.ObjectMeta.Namespace).Msgf("Modifying volume mounts '%s' containers ...", container.Name)
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
 		Name:      "piggy-env",

--- a/piggy-webhooks/service/secret.go
+++ b/piggy-webhooks/service/secret.go
@@ -64,8 +64,10 @@ var sanitizeEnvmap = map[string]bool{
 	"PIGGY_ALLOWED_SA":                 true,
 	"PIGGY_SKIP_VERIFY_TLS":            true,
 	"PIGGY_IGNORE_NO_ENV":              true,
-	"PIGGY_DEFAULT_SECRET_NAME_PREFIX": true,
-	"PIGGY_DEFAULT_SECRET_NAME_SUFFIX": true,
+	"PIGGY_DEFAULT_SECRET_NAME_PREFIX": true, // use before secret
+	"PIGGY_DEFAULT_SECRET_NAME_SUFFIX": true, // use before secret
+	"PIGGY_DNS_RESOLVER":               true, // use before secret
+	"PIGGY_DELAY_SECOND":               true, // use before secret
 }
 
 func (e *SanitizedEnv) append(name string, value string) {

--- a/piggy-webhooks/service/service.go
+++ b/piggy-webhooks/service/service.go
@@ -35,6 +35,7 @@ const ConfigImagePullSecret = "image-pull-secret" // Container image pull secret
 const ConfigImagePullSecretNamespace = "image-pull-secret-namespace" // Container image pull secret namespace
 const ConfigImageSkipVerifyRegistry = "image-skip-verify-registry"   // Default to true; not verify the registry
 const ConfigStandalone = "standalone"                                // Default to false; use piggy-webhook to read secrets instead of pod
+const ConfigPiggyDNSResolver = "piggy-dns-resolver"                  // Default to ""; Set Golang DNS resolver such as `tcp`, `udp`. See https://pkg.go.dev/net
 // use only when injecting secrets
 const ConfigPiggyEnforceServiceAccount = "piggy-enforce-service-account"      // Default to false; Force to check `PIGGY_ALLOWED_SA` env value in AWS secret manager
 const ConfigPiggyDefaultSecretNamePrefix = "piggy-default-secret-name-prefix" // Default to ""; Set default prefix string for secret name
@@ -60,6 +61,7 @@ type PiggyConfig struct {
 	ImagePullSecretNamespace         string            `json:"imagePullSecretNamespace"`
 	ImageSkipVerifyRegistry          bool              `json:"imageSkipVerifyRegistry"`
 	Standalone                       bool              `json:"standalone"`
+	PiggyDNSResolver                 string            `json:"piggyDNSResolver"`
 	// use only when injecting secrets
 	PiggyEnforceServiceAccount   bool   `json:"piggyEnforceServiceAccount"`
 	PiggyDefaultSecretNamePrefix string `json:"piggyDefaultSecretNamePrefix"`

--- a/piggy-webhooks/service/service.go
+++ b/piggy-webhooks/service/service.go
@@ -36,6 +36,7 @@ const ConfigImagePullSecretNamespace = "image-pull-secret-namespace" // Containe
 const ConfigImageSkipVerifyRegistry = "image-skip-verify-registry"   // Default to true; not verify the registry
 const ConfigStandalone = "standalone"                                // Default to false; use piggy-webhook to read secrets instead of pod
 const ConfigPiggyDNSResolver = "piggy-dns-resolver"                  // Default to ""; Set Golang DNS resolver such as `tcp`, `udp`. See https://pkg.go.dev/net
+const ConfigPiggyDelaySecond = "piggy-delay-second"                  // Default to 0; Delay in seconds before requesting secret from piggy-webhooks or secret-manager
 // use only when injecting secrets
 const ConfigPiggyEnforceServiceAccount = "piggy-enforce-service-account"      // Default to false; Force to check `PIGGY_ALLOWED_SA` env value in AWS secret manager
 const ConfigPiggyDefaultSecretNamePrefix = "piggy-default-secret-name-prefix" // Default to ""; Set default prefix string for secret name
@@ -62,6 +63,7 @@ type PiggyConfig struct {
 	ImageSkipVerifyRegistry          bool              `json:"imageSkipVerifyRegistry"`
 	Standalone                       bool              `json:"standalone"`
 	PiggyDNSResolver                 string            `json:"piggyDNSResolver"`
+	PiggyDelaySecond                 int               `json:"piggyDelaySecond"`
 	// use only when injecting secrets
 	PiggyEnforceServiceAccount   bool   `json:"piggyEnforceServiceAccount"`
 	PiggyDefaultSecretNamePrefix string `json:"piggyDefaultSecretNamePrefix"`
@@ -89,6 +91,19 @@ func GetEnvBool(name string, defaultValue bool) bool {
 	return b
 }
 
+// GetEnvInt get environment value as int or return default value if not found
+func GetEnvInt(name string, defaultValue int) int {
+	val := os.Getenv(name)
+	if val == "" {
+		return defaultValue
+	}
+	b, err := strconv.ParseInt(val, 10, 0)
+	if err != nil {
+		return defaultValue
+	}
+	return int(b)
+}
+
 // GetStringValue get a string value from annotation map
 func GetStringValue(annotations map[string]string, name string, defaultValue string) string {
 	if val, ok := annotations[Namespace+name]; ok {
@@ -106,4 +121,17 @@ func GetBoolValue(annotations map[string]string, name string, defaultValue bool)
 	}
 	envName := strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 	return GetEnvBool(envName, defaultValue)
+}
+
+// GetIntValue get a int value from annotation map
+func GetIntValue(annotations map[string]string, name string, defaultValue int) int {
+	if val, ok := annotations[Namespace+name]; ok {
+		b, err := strconv.ParseInt(val, 10, 0)
+		if err != nil {
+			return defaultValue
+		}
+		return int(b)
+	}
+	envName := strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
+	return GetEnvInt(envName, defaultValue)
 }


### PR DESCRIPTION
Add option to fix 
```
{"level":"error","time":"2021-09-14T10:36:14Z","message":"Error while requesting secret Post \"https://piggy-webhooks.piggy-webhooks.svc.cluster.local/secret\": dial tcp: lookup piggy-webhooks.piggy-webhooks.svc.cluster.local on 172.20.0.10:53: read udp 10.71.155.5:60637->172.20.0.10:53: read: connection refused" 
```

1) This problem may happen when kube-proxy decide to stale UDP service on coredns.
```
I0914 11:20:52.878526       1 proxier.go:812] Stale udp service kube-system/kube-dns:dns -> 172.20.0.10
```

Add an `PIGGY_DNS_RESOLVER` env or `piggysec.com/piggy-dns-resolver` annotation  to allow to use Golang DNS Resolver with `tcp` instead of default lookup or using `/etc/resolve.conf`. 

2) This problem may happen when using Istio Envoy on application. The Istio will block all outgoing requests until Envoy is fully operated. However, piggy-env is much faster than Envoy. So you need to add delay to piggy-env before start retrieving secrets. 

Add an `PIGGY_DELAY_SECOND` env or `piggysec.com/piggy-delay-second` annotation to delay piggy-env before start
