### PR TITLE
Exit 1 if piggy-env cant connects to piggy-webhooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,26 @@ docker-piggy-multi: ## Build a piggy-env and piggy-webhooks Docker image in mult
 		--build-arg=BUILD_DATE=$(BUILD_DATE) \
 		-f piggy-webhooks/Dockerfile piggy-webhooks
 
+.PHONY: docker-piggy-multi-push
+docker-piggy-multi-push: BUILD_ARCH := $(strip $(BUILD_ARCH)),linux/arm64
+docker-piggy-multi-push: ## Build a piggy-env and piggy-webhooks Docker image in multi-architect and push to GCR
+	@docker login ghcr.io -u USERNAME -p $(CR_PAT)
+	@echo "Building architecture ${BUILD_ARCH}"
+	docker buildx build -t ${PIGGY_ENV_DOCKER_IMAGE}:${DOCKER_TAG} \
+		--push \
+		--platform=$(BUILD_ARCH) \
+		--build-arg=VERSION=$(VERSION) \
+		--build-arg=COMMIT_HASH=$(COMMIT_HASH) \
+		--build-arg=BUILD_DATE=$(BUILD_DATE) \
+		-f piggy-env/Dockerfile piggy-env
+	docker buildx build -t ${PIGGY_WEBHOOK_DOCKER_IMAGE}:${DOCKER_TAG} \
+		--push \
+		--platform=$(BUILD_ARCH) \
+		--build-arg=VERSION=$(VERSION) \
+		--build-arg=COMMIT_HASH=$(COMMIT_HASH) \
+		--build-arg=BUILD_DATE=$(BUILD_DATE) \
+		-f piggy-webhooks/Dockerfile piggy-webhooks
+
 release-%: ## Release a new version
 	git tag -m 'Release $*' $*
 

--- a/piggy-env/main.go
+++ b/piggy-env/main.go
@@ -243,7 +243,7 @@ func install(src, dst string) error {
 			dst = dst + "/piggy-env"
 		}
 	}
-	destination, err := os.Create(dst)
+	destination, err := os.Create(filepath.Clean(dst))
 	if err != nil {
 		return err
 	}
@@ -369,6 +369,10 @@ func main() {
 		log.Info().Msgf("Sleeping for %s", initialDelay)
 		time.Sleep(initialDelay)
 	}
+	ignoreNoEnv := false
+	if os.Getenv("PIGGY_IGNORE_NO_ENV") != "" {
+		ignoreNoEnv, _ = strconv.ParseBool(os.Getenv("PIGGY_IGNORE_NO_ENV"))
+	}
 	retryResults := make([]string, numberOfRetry)
 	success := false
 	if standalone {
@@ -408,10 +412,9 @@ func main() {
 		for _, result := range retryResults {
 			log.Error().Msg(result)
 		}
-	}
-	ignoreNoEnv := false
-	if os.Getenv("PIGGY_IGNORE_NO_ENV") != "" {
-		ignoreNoEnv, _ = strconv.ParseBool(os.Getenv("PIGGY_IGNORE_NO_ENV"))
+		if !ignoreNoEnv {
+			log.Fatal().Msgf("Unable to communicate with %s", os.Getenv("PIGGY_ADDRESS"))
+		}
 	}
 	if !ignoreNoEnv {
 		for _, v := range sanitized.Env {


### PR DESCRIPTION
The piggy-env will exit immediately if it can't connect to piggy-webhooks in proxy mode.
This behavior can turn off by `PIGGY_IGNORE_NO_ENV=true`