### PR TITLE
Refactor service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
+![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Action](https://github.com/KongZ/piggy/workflows/Build%20to%20GHCR/badge.svg?branch=main)](https://github.com/KongZ/piggy/actions)
+[![Copilot Code Review](https://github.com/KongZ/piggy/actions/workflows/copilot-pull-request-reviewer/badge.svg)](https://github.com/KongZ/piggy/actions/workflows/copilot-pull-request-reviewer)
 [![CodeQL](https://github.com/KongZ/piggy/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/KongZ/piggy/actions/workflows/codeql-analysis.yml)
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/piggy)](https://artifacthub.io/packages/search?repo=piggy)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Go Version](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat&logo=go)
+![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?style=flat&logo=go)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Copilot Code Review](https://github.com/KongZ/piggy/actions/workflows/copilot-pull-request-reviewer/badge.svg)](https://github.com/KongZ/piggy/actions/workflows/copilot-pull-request-reviewer)
 [![CodeQL](https://github.com/KongZ/piggy/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/KongZ/piggy/actions/workflows/codeql-analysis.yml)

--- a/charts/piggy-webhooks/Chart.yaml
+++ b/charts/piggy-webhooks/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: piggy-webhooks
 description: Deploys a piggy-webhooks that inject environment variables from AWS Secrets Manager
 type: application
-version: 0.7.4
-appVersion: "0.7.4"
+version: 0.7.5
+appVersion: "0.7.5"
 home: https://piggysec.com
 icon: https://raw.githubusercontent.com/KongZ/piggy/refs/heads/main/docs/images/gopher-piggy.png
 sources:

--- a/charts/piggy-webhooks/templates/deployment.yaml
+++ b/charts/piggy-webhooks/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               value: {{ $val | quote }}
             {{- end }}
           ports:
-            - name: http
+            - name: tcp
               containerPort: {{ .Values.port }}
               protocol: TCP
           livenessProbe:

--- a/charts/piggy-webhooks/templates/service.yaml
+++ b/charts/piggy-webhooks/templates/service.yaml
@@ -8,8 +8,8 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: http
+      targetPort: tcp
       protocol: TCP
-      name: http
+      name: tcp
   selector:
     {{- include "piggy-webhooks.selectorLabels" . | nindent 4 }}

--- a/charts/piggy-webhooks/values.yaml
+++ b/charts/piggy-webhooks/values.yaml
@@ -11,7 +11,7 @@ image:
   ## Image pull policy.
   pullPolicy: IfNotPresent
   ## Overrides the image tag whose default is the chart appVersion.
-  tag: "0.7.4"
+  tag: "0.7.5"
 
 ## List of image pull secrets for the deployment.
 imagePullSecrets: []
@@ -188,7 +188,7 @@ mutate:
     ## Image pull policy for piggy-env.
     pullPolicy: IfNotPresent
     ## Image tag for piggy-env.
-    tag: "0.7.4"
+    tag: "0.7.5"
   ## If the pods being admitted is modified by other admission plugins after the initial webhook call,
   ## set this value to 'IfNeeded' to allow the webhook to be called again. Set to 'Never' to prevent the webhook from being called again.
   reinvocationPolicy: IfNeeded

--- a/piggy-webhooks/handler/admit_test.go
+++ b/piggy-webhooks/handler/admit_test.go
@@ -229,4 +229,15 @@ func TestAdmitHandler_Errors(t *testing.T) {
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+
+	// Case 4: Nil Request in AdmissionReview
+	review = admissionv1.AdmissionReview{
+		Request: nil,
+	}
+	body, _ = json.Marshal(review)
+	req, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", JSONContentType)
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }

--- a/piggy-webhooks/handler/admit_test.go
+++ b/piggy-webhooks/handler/admit_test.go
@@ -230,14 +230,4 @@ func TestAdmitHandler_Errors(t *testing.T) {
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
 
-	// Case 4: Nil Request in AdmissionReview
-	review = admissionv1.AdmissionReview{
-		Request: nil,
-	}
-	body, _ = json.Marshal(review)
-	req, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBuffer(body))
-	req.Header.Set("Content-Type", JSONContentType)
-	rr = httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }

--- a/piggy-webhooks/handler/secret_handler_test.go
+++ b/piggy-webhooks/handler/secret_handler_test.go
@@ -100,4 +100,25 @@ func TestSecretHandler_Errors(t *testing.T) {
 	rr = httptest.NewRecorder()
 	handler.ServeHTTP(rr, req)
 	assert.Equal(t, http.StatusForbidden, rr.Code)
+
+	// Case 5: Generic Error
+	secretFuncError := func(payload *service.GetSecretPayload) (*service.SanitizedEnv, service.Info, error) {
+		return nil, service.Info{}, assert.AnError
+	}
+	handler = SecretHandler(secretFuncError)
+	req, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"name":"pod"}`))
+	req.Header.Set("Content-Type", JSONContentType)
+	req.Header.Set("X-Token", "valid-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+
+	// Case 6: Empty Name
+	handler = SecretHandler(nil)
+	req, _ = http.NewRequest(http.MethodPost, "/", bytes.NewBufferString(`{"name":""}`))
+	req.Header.Set("Content-Type", JSONContentType)
+	req.Header.Set("X-Token", "valid-token")
+	rr = httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
 }

--- a/piggy-webhooks/main.go
+++ b/piggy-webhooks/main.go
@@ -55,10 +55,7 @@ func main() {
 		w.WriteHeader(200)
 	}))
 	mux.Handle("/mutate", handler.AdmitHandler(mut.ApplyPiggy))
-	svc, err := service.NewService(context.Background(), k8s)
-	if err != nil {
-		log.Fatal().Msgf("error creating service: %s", err)
-	}
+	svc := service.NewService(context.Background(), k8s)
 	mux.Handle("/secret", handler.SecretHandler(svc.GetSecret))
 	ch := make(chan struct{})
 	enabledTLS := !(certPath == "" && keyPath == "")

--- a/piggy-webhooks/mutate/mutate_test.go
+++ b/piggy-webhooks/mutate/mutate_test.go
@@ -6,13 +6,17 @@ import (
 	"os"
 	"testing"
 
+	"errors"
+
 	"github.com/KongZ/piggy/piggy-webhooks/service"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/stretchr/testify/assert"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 )
 
 // TestIsKubeNamespace verifies the identification of system namespaces.
@@ -246,6 +250,14 @@ func TestLookForValueFrom_ErrorCases(t *testing.T) {
 	res, err = m.LookForValueFrom(envSec, "default")
 	assert.NoError(t, err)
 	assert.Nil(t, res)
+
+	// K8s Error
+	client.PrependReactor("get", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.New("k8s error")
+	})
+	_, err = m.LookForValueFrom(envCM, "default")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s error")
 }
 
 // TestLookForEnvFrom_ErrorCases verifies handling of missing or optional sources in EnvFrom.
@@ -304,4 +316,130 @@ func TestMergeConfig(t *testing.T) {
 	assert.True(t, config.PiggyPspAllowPrivilegeEscalation)
 	assert.True(t, config.Debug)
 	assert.Equal(t, "http://env-address", config.PiggyAddress)
+}
+
+// TestMutateCommand_Error checks that mutation continues even if image config fetching fails (it logs error).
+func TestMutateCommand_Error(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset()
+	m, _ := NewMutating(ctx, client)
+
+	// Initialize registry manually as NewMutating doesn't do it
+	config := &service.PiggyConfig{
+		AWSSecretName: "my-secret",
+	}
+	m.registry = NewRegistry(config)
+
+	// Mock image fetcher to fail
+	m.registry.imageFetcher = func(ctx context.Context, config *service.PiggyConfig, container containerInfo) (*v1.Config, error) {
+		return nil, errors.New("registry error")
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-pod",
+			Annotations: map[string]string{
+				service.Namespace + service.AWSSecretName: "my-secret",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					// No command specified, so it triggers registry lookup
+				},
+			},
+		},
+	}
+	// config is already defined above
+
+	// Should not return error, but log it
+	_, _, err := m.mutateContainer("uid", config, &pod.Spec.Containers[0], pod)
+	assert.NoError(t, err)
+}
+
+// TestMutateContainer_FullConfig verifies that all configuration options are correctly injected as environment variables.
+func TestMutateContainer_FullConfig(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset()
+	m, _ := NewMutating(ctx, client)
+
+	// Initialize registry manually
+	conf := &service.PiggyConfig{}
+	m.registry = NewRegistry(conf)
+
+	// Mock registry to avoid actual lookup
+	m.registry.imageFetcher = func(ctx context.Context, config *service.PiggyConfig, container containerInfo) (*v1.Config, error) {
+		return &v1.Config{}, nil
+	}
+
+	config := &service.PiggyConfig{
+		AWSSecretName:         "my-secret",
+		AWSRegion:             "us-east-1",
+		PiggyAddress:          "http://piggy",
+		PiggyIgnoreNoEnv:      true,
+		PiggyDNSResolver:      "1.1.1.1",
+		PiggyInitialDelay:     "5s",
+		PiggyNumberOfRetry:    3,
+		PiggyEnforceIntegrity: true,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:    "app",
+				Command: []string{"echo"},
+				Env: []corev1.EnvVar{
+					{Name: "TRIGGER", Value: "piggy:trigger"},
+				},
+			}},
+		},
+	}
+
+	_, _, err := m.mutateContainer("uid", config, &pod.Spec.Containers[0], pod)
+	assert.NoError(t, err)
+
+	env := pod.Spec.Containers[0].Env
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_AWS_REGION", Value: "us-east-1"})
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_ADDRESS", Value: "http://piggy"})
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_IGNORE_NO_ENV", Value: "true"})
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_DNS_RESOLVER", Value: "1.1.1.1"})
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_INITIAL_DELAY", Value: "5s"})
+	assert.Contains(t, env, corev1.EnvVar{Name: "PIGGY_NUMBER_OF_RETRY", Value: "3"})
+}
+
+// TestMutateContainer_EnvFromError verifies that mutation fails if EnvFrom lookup errors out.
+func TestMutateContainer_EnvFromError(t *testing.T) {
+	ctx := context.Background()
+	client := fake.NewClientset()
+	m, _ := NewMutating(ctx, client)
+
+	// Inject K8s error
+	client.PrependReactor("get", "configmaps", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		return true, nil, errors.New("k8s error")
+	})
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name: "app",
+					EnvFrom: []corev1.EnvFromSource{
+						{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "missing"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	config := &service.PiggyConfig{}
+
+	_, _, err := m.mutateContainer("uid", config, &pod.Spec.Containers[0], pod)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "k8s error")
 }

--- a/piggy-webhooks/service/aws.go
+++ b/piggy-webhooks/service/aws.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"context"
+
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+// SecretsManagerClient defines the interface for AWS Secrets Manager client
+type SecretsManagerClient interface {
+	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+// SSMClient defines the interface for AWS SSM client
+type SSMClient interface {
+	GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
+}
+
+// AWSClientFactory defines the interface for creating AWS clients
+type AWSClientFactory interface {
+	GetSecretsManagerClient(ctx context.Context, region string) (SecretsManagerClient, error)
+	GetSSMClient(ctx context.Context, region string) (SSMClient, error)
+}
+
+// DefaultAWSClientFactory is the default implementation that creates real AWS clients
+type DefaultAWSClientFactory struct{}
+
+func (f *DefaultAWSClientFactory) GetSecretsManagerClient(ctx context.Context, region string) (SecretsManagerClient, error) {
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(region))
+	if err != nil {
+		return nil, err
+	}
+	return secretsmanager.NewFromConfig(cfg), nil
+}
+
+func (f *DefaultAWSClientFactory) GetSSMClient(ctx context.Context, region string) (SSMClient, error) {
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(region))
+	if err != nil {
+		return nil, err
+	}
+	return ssm.NewFromConfig(cfg), nil
+}

--- a/piggy-webhooks/service/aws_test.go
+++ b/piggy-webhooks/service/aws_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultAWSClientFactory(t *testing.T) {
+	f := &DefaultAWSClientFactory{}
+	ctx := context.Background()
+	region := "us-east-1"
+
+	// Test SecretsManager
+	sm, err := f.GetSecretsManagerClient(ctx, region)
+	assert.NoError(t, err)
+	assert.NotNil(t, sm)
+
+	// Test SSM
+	ssm, err := f.GetSSMClient(ctx, region)
+	assert.NoError(t, err)
+	assert.NotNil(t, ssm)
+}

--- a/piggy-webhooks/service/mock_clients_test.go
+++ b/piggy-webhooks/service/mock_clients_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+type MockSecretsManagerClient struct {
+	GetSecretValueFunc func(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (m *MockSecretsManagerClient) GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	if m.GetSecretValueFunc != nil {
+		return m.GetSecretValueFunc(ctx, params, optFns...)
+	}
+	return &secretsmanager.GetSecretValueOutput{}, nil
+}
+
+type MockSSMClient struct {
+	GetParametersByPathFunc func(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error)
+}
+
+func (m *MockSSMClient) GetParametersByPath(ctx context.Context, params *ssm.GetParametersByPathInput, optFns ...func(*ssm.Options)) (*ssm.GetParametersByPathOutput, error) {
+	if m.GetParametersByPathFunc != nil {
+		return m.GetParametersByPathFunc(ctx, params, optFns...)
+	}
+	return &ssm.GetParametersByPathOutput{}, nil
+}
+
+type MockAWSClientFactory struct {
+	GetSecretsManagerClientFunc func(ctx context.Context, region string) (SecretsManagerClient, error)
+	GetSSMClientFunc            func(ctx context.Context, region string) (SSMClient, error)
+}
+
+func (m *MockAWSClientFactory) GetSecretsManagerClient(ctx context.Context, region string) (SecretsManagerClient, error) {
+	if m.GetSecretsManagerClientFunc != nil {
+		return m.GetSecretsManagerClientFunc(ctx, region)
+	}
+	return &MockSecretsManagerClient{}, nil
+}
+
+func (m *MockAWSClientFactory) GetSSMClient(ctx context.Context, region string) (SSMClient, error) {
+	if m.GetSSMClientFunc != nil {
+		return m.GetSSMClientFunc(ctx, region)
+	}
+	return &MockSSMClient{}, nil
+}

--- a/piggy-webhooks/service/secret_test.go
+++ b/piggy-webhooks/service/secret_test.go
@@ -250,6 +250,7 @@ func TestInjectSecrets_Success(t *testing.T) {
 
 	svc := &Service{
 		awsFactory: mockFactory,
+		context:    context.Background(),
 	}
 
 	config := &PiggyConfig{
@@ -275,6 +276,7 @@ func TestInjectSecrets_Error(t *testing.T) {
 
 	svc := &Service{
 		awsFactory: mockFactory,
+		context:    context.Background(),
 	}
 
 	config := &PiggyConfig{
@@ -311,6 +313,7 @@ func TestInjectParameters_Success(t *testing.T) {
 
 	svc := &Service{
 		awsFactory: mockFactory,
+		context:    context.Background(),
 	}
 
 	config := &PiggyConfig{

--- a/piggy-webhooks/service/service.go
+++ b/piggy-webhooks/service/service.go
@@ -99,13 +99,13 @@ type Service struct {
 }
 
 // NewService new service
-func NewService(ctx context.Context, k8sClient kubernetes.Interface) (*Service, error) {
+func NewService(ctx context.Context, k8sClient kubernetes.Interface) *Service {
 	svc := &Service{
 		context:    ctx,
 		k8sClient:  k8sClient,
 		awsFactory: &DefaultAWSClientFactory{},
 	}
-	return svc, nil
+	return svc
 }
 
 // GetEnv get environment value or return default value if not found

--- a/piggy-webhooks/service/service.go
+++ b/piggy-webhooks/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"os"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -88,6 +90,22 @@ type PiggyConfig struct {
 	PiggyDefaultSecretNameSuffix string `json:"piggyDefaultSecretNameSuffix"`
 	//
 	PodServiceAccountName string
+}
+
+type Service struct {
+	context    context.Context
+	k8sClient  kubernetes.Interface
+	awsFactory AWSClientFactory
+}
+
+// NewService new service
+func NewService(ctx context.Context, k8sClient kubernetes.Interface) (*Service, error) {
+	svc := &Service{
+		context:    ctx,
+		k8sClient:  k8sClient,
+		awsFactory: &DefaultAWSClientFactory{},
+	}
+	return svc, nil
 }
 
 // GetEnv get environment value or return default value if not found


### PR DESCRIPTION
1. Service Package Refactoring
* Add dependency Injection so it can be use with mock test
* Add mock test
2. Mutate Package Refactoring
* Add pluggable imageFetcher function so it can be use with mock test
3. To prevent Istio from guessing the service port name incorrectly, rename the Kubernetes service port from `http` to `tcp`.

|Package|Coverage|
|---|---|
|piggy-webhooks/handler|80.6%|
|piggy-webhooks/mutate|84.9%|
|piggy-webhooks/service|89%|



